### PR TITLE
Add Windows support and some tests

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+
+
+class PassingTest(unittest.TestCase):
+    def test_one(self):
+        print 'pid: %d' % os.getpid()
+
+
+class FailingTest(unittest.TestCase):
+    def test_one(self):
+        self.assertTrue(False)
+
+
+class ErroringTest(unittest.TestCase):
+    def test_one(self):
+        raise Exception('error')
+
+
+class SkippedTest(unittest.TestCase):
+    @unittest.skip('skip reason')
+    def test_one(self):
+        pass

--- a/tests/test_nose_xunitmp.py
+++ b/tests/test_nose_xunitmp.py
@@ -1,0 +1,81 @@
+# encoding: utf-8
+
+import os
+import unittest
+import tempfile
+import xml.etree.ElementTree as ET
+
+import nose.plugins
+
+from nose_xunitmp import XunitMP
+
+
+_here = os.path.dirname(__file__)
+
+
+class TestProducesOutput(nose.plugins.PluginTester, unittest.TestCase):
+    activate = '--with-xunitmp'
+    plugins = [XunitMP(), nose.plugins.multiprocess.MultiProcess()]
+    suitepath = os.path.join(_here, 'support.py')
+    args = ['--processes=2']
+
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp(suffix='.xml')
+        os.close(fd)
+        self.args += ['--xunitmp-file=%s' % self.path]
+        # Due to the way PluginTester works, the plugins in self.plugins are
+        # not automatically loaded in the test processes. If we add them to
+        # _instantiate_plugins, then the multiprocessing plugin will load them.
+        nose.plugins.multiprocess._instantiate_plugins = [p.__class__ for p in
+                                                          self.plugins]
+        # PluginTester's setUp() does the actual test run
+        super(TestProducesOutput, self).setUp()
+        self.xml = ET.parse(self.path)
+        self.root = self.xml.getroot()
+
+    def tearDown(self):
+        os.remove(self.path)
+
+    def test_stats(self):
+        """Stats should be included on the <testsuite> element."""
+        self.assertEqual(self.root.attrib['tests'], '4')
+        self.assertEqual(self.root.attrib['errors'], '1')
+        self.assertEqual(self.root.attrib['failures'], '1')
+        self.assertEqual(self.root.attrib['skip'], '1')
+
+    def test_number_of_testcase_elements(self):
+        """The number of <testcase> elements should match the number of tests."""
+        testcases = self.root.findall('testcase')
+        self.assertEqual(len(testcases), 4)
+
+    def test_skip(self):
+        """Skipped tests should appear in the output."""
+        testcase = self.root.find('./testcase[@classname="support.SkippedTest"]')
+        self.assertNotEqual(testcase, None)
+
+    def test_passing(self):
+        """Passing tests should appear in the output."""
+        testcase = self.root.find('./testcase[@classname="support.PassingTest"]')
+        self.assertNotEqual(testcase, None)
+
+    def test_failing(self):
+        """Failing tests should appear in the output."""
+        testcase = self.root.find('./testcase[@classname="support.FailingTest"]')
+        self.assertNotEqual(testcase, None)
+
+    def test_errored(self):
+        """Errored tests should appear in the output."""
+        testcase = self.root.find('./testcase[@classname="support.ErroringTest"]')
+        self.assertNotEqual(testcase, None)
+
+    def test_different_pid(self):
+        """Check that the tests ran in a different process.
+
+        We can't force them to all run in different processes, but we can check
+        that they've run in a different process to these tests, which should
+        be sufficient to catch most errors.
+        """
+        testcase = self.root.find('./testcase[@classname="support.PassingTest"]')
+        systemout = testcase.find('system-out')
+        test_pid = systemout.text.replace('pid: ', '').replace('\n', '')
+        self.assertNotEqual(str(os.getpid()), test_pid)


### PR DESCRIPTION
The actual change is to move the creation of `errorlist` and `stats` into the plugin's `configure()`. This has a number of advantages:
* They are only created once - in the main test process when they are the plugin is first `configure()`d. (Nose's multiprocessing plugin re-instantiates all plugins in each test process)
* We only set the initial values of stats once. Previously we were doing it from each test subprocess (as the plugin is `configure()`d in each), which meant that the test stats could be overwritten/lost if tests ran quick enough. (This happens sometimes for the tests in `tests/support.py`).
* It should work on Windows. Windows doesn't support `fork()`ing processes and Python re-imports modules in each subprocess, which means that each process got its own `MANAGER`/`MP_STATS`/`MP_ERRORLIST`. Storing the `stats`/`errorlist` on `self.config` means that nose copies them into each subprocess for us to pick up. (Nose's multiprocessing plugin pickles `config` and copies it into each subprocess).

The tests are there to make sure I didn't break anything. I've run them on OS X and Windows and confirmed that they pass. You can run them by doing `nosetests .` at the root of the repo.