### PR TITLE
Adding new 'xunit_prefix_class' var that nose expects to be defined.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+0.4.1
+---
+
+-  Fix 'xunit_prefix_class' exception
+
 0.4
 ---
 

--- a/nose_xunitmp.py
+++ b/nose_xunitmp.py
@@ -14,6 +14,7 @@ class XunitMP(Xunit):
     score = 2000
     error_report_filename = None
     error_report_file = None
+    xunit_prefix_class = None
 
     def options(self, parser, env):
         """Sets additional command line options."""

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requires = [
 
 
 setup(name='nose_xunitmp',
-      version='0.4.0',
+      version='0.4.1',
       description='Xunit output when running multiprocess tests using nose',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[


### PR DESCRIPTION
Newer version of nose require this var to exist or an exception is thrown.